### PR TITLE
Use the latest cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,6 +16,7 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_COMMAND: "python -m unittest discover -v {project}/test"
   CIBW_BUILD: "cp39-* cp31?-*"
+  CIBW_DEPENDENCY_VERSIONS: latest
 
 jobs:
   build_wheels:
@@ -29,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.3
+        uses: pypa/cibuildwheel@v2.16.2
 
       - uses: actions/upload-artifact@v3
         with:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     include_package_data=True,
     setup_requires=[
         'setuptools>=18.0',
-        'cython'
+        'cython<3.0.0'
     ],
     test_suite="test",
     classifiers=[


### PR DESCRIPTION
Also use the latest build dependencies to avoid build errors.

I can't actually trigger the CI runs, but I think this should resolve the build errors seen in https://github.com/Penlect/rectangle-packer/pull/21#issuecomment-1731990526. See also https://github.com/cython/cython/issues/5568, https://github.com/pypa/cibuildwheel/issues/1612