### PR TITLE
Fix bounding box forwarding of zero values

### DIFF
--- a/rpack/__init__.py
+++ b/rpack/__init__.py
@@ -218,4 +218,6 @@ def pack(
         raise TypeError("max_height must be an integer")
     if not isinstance(sizes, list):
         sizes = list(sizes)
-    return _pack(sizes, max_width or -1, max_height or -1)
+    mw = -1 if max_width is None else max_width
+    mh = -1 if max_height is None else max_height
+    return _pack(sizes, mw, mh)

--- a/test/test_pack.py
+++ b/test/test_pack.py
@@ -119,6 +119,14 @@ class TestPackInputBoundingBoxRestrictions(unittest.TestCase):
     def test_max_height_ok(self):
         rpack.pack([(2, 2)], max_height=2)
 
+    def test_max_width_zero(self):
+        with self.assertRaisesRegex(rpack.PackingImpossibleError, "max_width zero"):
+            rpack.pack([(2, 2)], max_width=0)
+
+    def test_max_height_zero(self):
+        with self.assertRaisesRegex(rpack.PackingImpossibleError, "max_height zero"):
+            rpack.pack([(2, 2)], max_height=0)
+
     def test_partial_result(self):
         with self.assertRaises(rpack.PackingImpossibleError) as error:
             rpack.pack([(2, 2)] * 4, max_width=3, max_height=3)


### PR DESCRIPTION
## Summary
- ensure `pack` forwards integer bounds unmodified
- add tests for zero-valued `max_width` and `max_height`

## Testing
- `python3 -m unittest discover -v test` *(fails: ModuleNotFoundError: No module named 'rpack._core')*