### PR TITLE
Bump cibuildwheel to 3.2.1 and add Py 3.14 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,6 +16,9 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_COMMAND: "python -m unittest discover -v {project}/test"
   CIBW_BUILD: "cp39-* cp31?-*"
+  # Explicitly skip free-threaded ("t") builds across 3.10–3.14
+  # to keep parity with prior artifacts until opted in.
+  CIBW_SKIP: "cp31?t-*"
 
 jobs:
   build_wheels:
@@ -30,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.2.1
         # env:
         #   CIBW_SOME_OPTION: value
         #    ...

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
 )


### PR DESCRIPTION
- Update GitHub Actions workflow to pypa/cibuildwheel@v3.2.1.
- Keep build pattern cp39-* and cp31?-* to include cp314.
- Explicitly skip free-threaded wheels via CIBW_SKIP=cp31?t-*.
- Add Python 3.14 classifier to setup.py.
- Leave Cython unpinned to avoid forcing user upgrades.