### PR TITLE
Stop building wheels for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -15,8 +15,8 @@ on:
 env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_TEST_COMMAND: "python -m unittest discover -v {project}/test"
-  CIBW_BUILD: "cp39-* cp31?-*"
-  # Explicitly skip free-threaded ("t") builds across 3.10–3.14
+  CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
+  # Explicitly skip free-threaded ("t") builds across 3.11–3.14
   # to keep parity with prior artifacts until opted in.
   CIBW_SKIP: "cp31?t-*"
 


### PR DESCRIPTION
## Summary
- update the cibuildwheel matrix to drop CPython 3.9 and 3.10 builds
- align the free-threaded skip comment with the supported interpreter range

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5ffe4298833088a27e5aff8a4bce)