### PR TITLE
Update build status badge to GitHub Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,8 +129,8 @@ a solution to a problem discussed at stackoverflow_.
 .. |PyPI-Wheel| image:: https://img.shields.io/pypi/wheel/rectangle-packer.svg
    :target: https://pypi.org/project/rectangle-packer
 
-.. |Build-Status| image:: https://travis-ci.com/Penlect/rectangle-packer.svg?branch=master
-   :target: https://travis-ci.com/Penlect/rectangle-packer
+.. |Build-Status| image:: https://github.com/Penlect/rectangle-packer/actions/workflows/build_wheels.yml/badge.svg?branch=master
+   :target: https://github.com/Penlect/rectangle-packer/actions/workflows/build_wheels.yml
 
 .. |Read-the-Docs| image:: https://img.shields.io/readthedocs/rectangle-packer.svg
    :target: https://rectangle-packer.readthedocs.io/en/latest

--- a/rpack/__init__.py
+++ b/rpack/__init__.py
@@ -118,8 +118,8 @@ illustrates a solution to a problem discussed at stackoverflow_.
 .. |PyPI-Wheel| image:: https://img.shields.io/pypi/wheel/rectangle-packer.svg
    :target: https://pypi.org/project/rectangle-packer
 
-.. |Build-Status| image:: https://travis-ci.com/Penlect/rectangle-packer.svg?branch=master
-   :target: https://travis-ci.com/Penlect/rectangle-packer
+.. |Build-Status| image:: https://github.com/Penlect/rectangle-packer/actions/workflows/build_wheels.yml/badge.svg?branch=master
+   :target: https://github.com/Penlect/rectangle-packer/actions/workflows/build_wheels.yml
 
 .. |Read-the-Docs| image:: https://img.shields.io/readthedocs/rectangle-packer.svg
    :target: https://rectangle-packer.readthedocs.io/en/latest


### PR DESCRIPTION
## Summary
- replace the broken Travis CI build badge with the GitHub Actions workflow badge in README
- mirror the badge link change in the package documentation string

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5fd165a0833085e7109a5c74d6aa)