### PR TITLE
Use size_t for RectangleSet length

### DIFF
--- a/rpack/_core.pyx
+++ b/rpack/_core.pyx
@@ -87,7 +87,7 @@ cdef class RectangleSet:
 
     cdef:
         Rectangle *rectangles
-        Py_ssize_t length
+        size_t length
         long sum_width
         long sum_height
 


### PR DESCRIPTION
Align RectangleSet.length with size_t loop/index usage to avoid signed/unsigned comparisons in generated Cython C.

This removes repeated -Wsign-compare warnings from rpack/_core.c without changing packing behavior.

Closes #44 