### PR TITLE
Guard cell split index bounds

### DIFF
--- a/include/rpackcore.h
+++ b/include/rpackcore.h
@@ -79,7 +79,7 @@ Grid *grid_alloc(size_t size, long width, long height);
 void grid_free(Grid *grid);
 void grid_clear(Grid *self);
 int grid_find_region(Grid *grid, Rectangle *rectangle, Region *reg);
-void grid_split(Grid *self, Region *reg);
+int grid_split(Grid *self, Region *reg);
 long grid_search_bbox(Grid *grid, Rectangle *sizes, BBoxRestrictions *bbr);
 
 #endif

--- a/rpack/_core.pxd
+++ b/rpack/_core.pxd
@@ -38,5 +38,5 @@ cdef extern from "rpackcore.h":
         void grid_free(CGrid *grid) nogil
         void grid_clear(CGrid *self) nogil
         int grid_find_region(CGrid *grid, Rectangle *rectangle, Region *reg) nogil
-        void grid_split(CGrid *self, Region *reg) nogil
+        int grid_split(CGrid *self, Region *reg) nogil
         long grid_search_bbox(CGrid *grid, Rectangle *sizes, BBoxRestrictions *bbr) nogil

--- a/rpack/_core.pyx
+++ b/rpack/_core.pyx
@@ -264,6 +264,7 @@ cdef class Grid:
 
     cdef int pack(self, RectangleSet rset, long width, long height) except -1:
         cdef size_t i = 0
+        cdef int split_status
         cdef Region reg
         if self.cgrid.size + 1 < rset.length:
             raise PackingImpossibleError(
@@ -281,7 +282,11 @@ cdef class Grid:
                     return 1
                 r.x = start_pos(reg.col_cell_start)
                 r.y = start_pos(reg.row_cell_start)
-                grid_split(self.cgrid, &reg)
+                split_status = grid_split(self.cgrid, &reg)
+                if split_status != 0:
+                    r.x = NO_POSITION
+                    r.y = NO_POSITION
+                    return 1
         return 0
 
 


### PR DESCRIPTION
Add explicit bounds checks before using CellLink.jump_index in cut.

Make cut and grid_split return status so split failures can be propagated safely instead of risking out-of-bounds writes.

Handle grid_split failures in grid_search_bbox and Cython Grid.pack, and add regression tests for exhausted CellLink/Grid cases.

Closes #46 