### PR TITLE
Use long in rectangle area comparator

### DIFF
--- a/rpack/_core.pyx
+++ b/rpack/_core.pyx
@@ -71,7 +71,7 @@ cdef int rectangle_height_cmp(const void *a, const void *b) noexcept nogil:
 
 
 cdef int rectangle_area_cmp(const void *a, const void *b) noexcept nogil:
-    cdef int area_a, area_b
+    cdef long area_a, area_b
     area_a = (<Rectangle*>a)[0].area
     area_b = (<Rectangle*>b)[0].area
     if area_a < area_b:


### PR DESCRIPTION
Avoid truncating Rectangle.area values in rectangle_area_cmp by using long local variables instead of int.

This keeps sort tie-breaking correct for areas above INT_MAX.

Closes #48 