### PR TITLE
Fix large-height stalls from int truncation

### DIFF
--- a/include/rpackcore.h
+++ b/include/rpackcore.h
@@ -78,7 +78,7 @@ typedef struct grid Grid;
 Grid *grid_alloc(size_t size, long width, long height);
 void grid_free(Grid *grid);
 void grid_clear(Grid *self);
-int grid_find_region(Grid *grid, Rectangle *rectangle, Region *reg);
+long grid_find_region(Grid *grid, Rectangle *rectangle, Region *reg);
 int grid_split(Grid *self, Region *reg);
 long grid_search_bbox(Grid *grid, Rectangle *sizes, BBoxRestrictions *bbr);
 

--- a/rpack/_core.pxd
+++ b/rpack/_core.pxd
@@ -37,6 +37,6 @@ cdef extern from "rpackcore.h":
         CGrid *grid_alloc(size_t size, long width, long height) nogil
         void grid_free(CGrid *grid) nogil
         void grid_clear(CGrid *self) nogil
-        int grid_find_region(CGrid *grid, Rectangle *rectangle, Region *reg) nogil
+        long grid_find_region(CGrid *grid, Rectangle *rectangle, Region *reg) nogil
         int grid_split(CGrid *self, Region *reg) nogil
         long grid_search_bbox(CGrid *grid, Rectangle *sizes, BBoxRestrictions *bbr) nogil

--- a/rpack/_core.pyx
+++ b/rpack/_core.pyx
@@ -47,7 +47,7 @@ cdef int rectangle_index_cmp(const void *a, const void *b) noexcept nogil:
 
 
 cdef int rectangle_width_cmp(const void *a, const void *b) noexcept nogil:
-    cdef int width_a, width_b
+    cdef long width_a, width_b
     width_a = (<Rectangle*>a)[0].width
     width_b = (<Rectangle*>b)[0].width
     if width_a < width_b:
@@ -59,7 +59,7 @@ cdef int rectangle_width_cmp(const void *a, const void *b) noexcept nogil:
 
 
 cdef int rectangle_height_cmp(const void *a, const void *b) noexcept nogil:
-    cdef int height_a, height_b
+    cdef long height_a, height_b
     height_a = (<Rectangle*>a)[0].height
     height_b = (<Rectangle*>b)[0].height
     if height_a < height_b:

--- a/src/rpackcore.c
+++ b/src/rpackcore.c
@@ -391,7 +391,7 @@ int grid_split(Grid * self, Region * reg)
 
 /* grid_find_region searches the grid for a free space that can
    contain the region `reg`. */
-int grid_find_region(Grid * grid, Rectangle * rectangle, Region * reg)
+long grid_find_region(Grid * grid, Rectangle * rectangle, Region * reg)
 {
     long rec_col_end_pos, rec_row_end_pos;
     long delta = rectangle->height;


### PR DESCRIPTION
# Fix large-height stall from 32-bit truncation in core path

Closes #53 

## Problem

`rpack.pack()` could stall on very small inputs when rectangle dimensions
exceeded `2^31-1`, despite running on 64-bit platforms.

Reproducer:

```python
rpack.pack([(1, 2147483648)] * 2)
```

Expected: near-instant return.  
Before this change: could hang/time out.

## Root cause

Two truncation issues:

1. `rpack/_core.pyx` comparators (`rectangle_width_cmp`,
   `rectangle_height_cmp`) copied `long` rectangle dimensions into `int`.
2. `grid_find_region()` computed a `long delta` but returned `int`,
   truncating large step values.

Both issues can break ordering/step logic for large dimensions and produce
pathological runtime.

## Changes in this MR

1. Comparator width/height types fixed:
   - `rpack/_core.pyx`
   - `int -> long` in width/height comparator temporaries.

2. `grid_find_region` return type corrected end-to-end:
   - `include/rpackcore.h`: `int -> long`
   - `src/rpackcore.c`: `int -> long`
   - `rpack/_core.pxd`: `int -> long`

3. Regression coverage:
   - `test/test_pack.py` adds
     `test_pack_does_not_stall_above_32bit_int_height`
   - runs `rpack.pack([(1, 2147483648)] * 2)` in a subprocess with timeout,
     and checks completion/result.

## Validation

- Targeted regression tests pass.
- `make test` passes.

## Risk assessment

- Low API risk: no public API change.
- Medium internal impact: comparator and search-step type correctness for
  large dimensions.
- Positive effect: removes severe stall class and aligns types with existing
  `long`-based rectangle/grid representation.
