### PR TITLE
C/Cython safety and hygiene cleanup

### DIFF
--- a/include/rpackcore.h
+++ b/include/rpackcore.h
@@ -13,7 +13,7 @@ struct cell {
 };
 typedef struct cell Cell;
 
-long start_pos(Cell *cell);
+long start_pos(const Cell *cell);
 
 // CellLink
 struct cell_link {
@@ -78,8 +78,9 @@ typedef struct grid Grid;
 Grid *grid_alloc(size_t size, long width, long height);
 void grid_free(Grid *grid);
 void grid_clear(Grid *self);
-long grid_find_region(Grid *grid, Rectangle *rectangle, Region *reg);
+long grid_find_region(Grid *grid, const Rectangle *rectangle, Region *reg);
 int grid_split(Grid *self, Region *reg);
-long grid_search_bbox(Grid *grid, Rectangle *sizes, BBoxRestrictions *bbr);
+long grid_search_bbox(Grid *grid, const Rectangle *sizes,
+                      const BBoxRestrictions *bbr);
 
 #endif

--- a/include/rpackcore.h
+++ b/include/rpackcore.h
@@ -1,5 +1,5 @@
-#ifndef CORE_H
-#define CORE_H
+#ifndef RPACKCORE_H
+#define RPACKCORE_H
 
 #include <stdlib.h>
 

--- a/rpack/_core.pxd
+++ b/rpack/_core.pxd
@@ -14,7 +14,7 @@ cdef extern from "rpackcore.h":
 
     ctypedef struct Cell
 
-    cdef long start_pos(Cell *cell) nogil
+    cdef long start_pos(const Cell *cell) nogil
 
     ctypedef struct Region:
         Cell *row_cell_start
@@ -37,6 +37,7 @@ cdef extern from "rpackcore.h":
         CGrid *grid_alloc(size_t size, long width, long height) nogil
         void grid_free(CGrid *grid) nogil
         void grid_clear(CGrid *self) nogil
-        long grid_find_region(CGrid *grid, Rectangle *rectangle, Region *reg) nogil
+        long grid_find_region(CGrid *grid, const Rectangle *rectangle, Region *reg) nogil
         int grid_split(CGrid *self, Region *reg) nogil
-        long grid_search_bbox(CGrid *grid, Rectangle *sizes, BBoxRestrictions *bbr) nogil
+        long grid_search_bbox(CGrid *grid, const Rectangle *sizes,
+                              const BBoxRestrictions *bbr) nogil

--- a/src/rpackcore.c
+++ b/src/rpackcore.c
@@ -19,8 +19,8 @@ $ indent -kr --no-tabs rpackcore.c
    ====
 */
 
-Cell _cell;
-Cell *const COL_FULL = &_cell;
+static Cell col_full_sentinel;
+static Cell *const COL_FULL = &col_full_sentinel;
 /* Coarse-search defaults tuned from thin-rectangle pathology benchmarks.
    The small-delta triggers cut long height scans; local refinement keeps
    the final bbox close to the best dense region. */

--- a/src/rpackcore.c
+++ b/src/rpackcore.c
@@ -132,18 +132,23 @@ static CellLink *alloc_cell_link(size_t size, long end_pos)
 {
     CellLink *cl = NULL;
     Cell *cells = NULL;
+
+    if (size == 0) {
+        size = 1;
+    }
+    if (end_pos == 0) {
+        end_pos = 1;
+    }
+    if (size > SIZE_MAX / sizeof(*cells)) {
+        return NULL;
+    }
+
     if ((cl = malloc(sizeof(*cl))) == NULL) {
         return NULL;
     }
     if ((cells = calloc(size, sizeof(*cells))) == NULL) {
         free(cl);
         return NULL;
-    }
-    if (size == 0) {
-        size = 1;
-    }
-    if (end_pos == 0) {
-        end_pos = 1;
     }
     cl->size = size;
     cl->end_pos = end_pos;

--- a/src/rpackcore.c
+++ b/src/rpackcore.c
@@ -73,7 +73,7 @@ long_add_overflows(long a, long b)
 
 /* start_pos computes the starting position of a Cell by returning the
    end position of the previous cell. */
-long start_pos(Cell * self)
+long start_pos(const Cell * self)
 {
     if (self == NULL) {
         return 0;
@@ -408,7 +408,7 @@ int grid_split(Grid * self, Region * reg)
 
 /* grid_find_region searches the grid for a free space that can
    contain the region `reg`. */
-long grid_find_region(Grid * grid, Rectangle * rectangle, Region * reg)
+long grid_find_region(Grid * grid, const Rectangle * rectangle, Region * reg)
 {
     long rec_col_end_pos, rec_row_end_pos;
     long delta = rectangle->height;
@@ -534,8 +534,8 @@ long grid_find_region(Grid * grid, Rectangle * rectangle, Region * reg)
 }
 
 static int
-grid_try_pack(Grid * grid, Rectangle * sizes, long delta_init, long *delta_out,
-              long *grid_w_out)
+grid_try_pack(Grid * grid, const Rectangle * sizes, long delta_init,
+              long *delta_out, long *grid_w_out)
 {
     size_t i = 0;
     long delta = delta_init;
@@ -575,8 +575,9 @@ grid_try_pack(Grid * grid, Rectangle * sizes, long delta_init, long *delta_out,
 }
 
 static void
-grid_refine_neighborhood(Grid * grid, Rectangle * sizes, BBoxRestrictions * bbr,
-                         long *best_area, long *best_h, long *best_w,
+grid_refine_neighborhood(Grid * grid, const Rectangle * sizes,
+                         const BBoxRestrictions * bbr, long *best_area,
+                         long *best_h, long *best_w,
                          long radius)
 {
     long h_start, h_stop, h, width_limit, candidate_area;
@@ -638,7 +639,8 @@ grid_refine_neighborhood(Grid * grid, Rectangle * sizes, BBoxRestrictions * bbr,
    contain all the rectangles, `sizes`, in the `grid`. The bounding
    box must also satisfy the bounding box restrictions `bbr`. */
 long
-grid_search_bbox(Grid * grid, Rectangle * sizes, BBoxRestrictions * bbr)
+grid_search_bbox(Grid * grid, const Rectangle * sizes,
+                 const BBoxRestrictions * bbr)
 {
     long happy_area = 1;        /* Todo */
     long start_width, start_area, area, best_h, best_w, delta, grid_w;


### PR DESCRIPTION
## Summary
This MR applies a narrow set of C/Cython safety and hygiene improvements in
`rpack` core internals. The goal is to reduce maintenance risk and warning
noise while keeping runtime behavior unchanged.

## What changed
1. **Hardened `CellLink` allocation path**
- `alloc_cell_link` now normalizes zero-size before allocation and checks
  allocation size overflow more defensively.
- This avoids undefined behavior risk around zero-sized allocations.

2. **Internalized sentinel symbol and removed reserved identifier**
- Replaced global `_cell` sentinel usage with internal static
  `col_full_sentinel`.
- Avoids reserved-identifier usage and unnecessary exported global symbol.

3. **Header guard cleanup**
- `include/rpackcore.h` guard changed from generic `CORE_H` to
  project-specific `RPACKCORE_H`.

4. **Const-correctness across C + Cython boundary**
- Updated read-only rectangle/bbox inputs to `const` in:
  - `include/rpackcore.h`
  - `src/rpackcore.c`
  - `rpack/_core.pxd`
- This aligns signatures and removes discarded-qualifier warnings.

## Validation
- Ran `make test` on this branch.
- Result: C tests pass, Python tests pass.
- Summary: `Ran 81 tests in 7.277s` / `OK (skipped=1)`.

## Risk assessment
- Expected user-visible behavior change: **none**.
- Scope is limited to internal safety/hygiene and type-contract cleanup.
